### PR TITLE
Clear cache session bug

### DIFF
--- a/src/app/api/signout/route.ts
+++ b/src/app/api/signout/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { invalidateSession } from '@/app/lib/auth';
 import { deleteSessionTokenCookie } from '@/app/lib/session';
 import { cookies } from 'next/headers';
+import { clearCache } from '@/app/lib/cache';
 
 export async function POST() {
   try {
@@ -9,12 +10,18 @@ export async function POST() {
     
     // invalidate the session in the DB
     if (sessionCookie && sessionCookie.value) {
+      console.log('Invalidating session:', sessionCookie.value);
       await invalidateSession(sessionCookie.value);
     }
     
     // Clear the session cookie using the utility function
+    console.log('Deleting session cookie');
     await deleteSessionTokenCookie();
-    
+
+    // clear out cache
+    console.log('Clearing cache');
+    clearCache()
+
     console.log('Successfully signed out user');
     return NextResponse.json({ 
       success: true, 

--- a/src/app/components/home/LocationWidgetWrapper.tsx
+++ b/src/app/components/home/LocationWidgetWrapper.tsx
@@ -6,6 +6,7 @@ import LocationWidget from "./LocationWidget";
 export default function LocationWidgetWrapper() {
   const [loading, setLoading] = useState<boolean>(false)
   const [locations, setLocations] = useState<MalaData[]>([])
+  const [error, setError] = useState<string | null>(null)
 
     useEffect(() => {
       const fetchData = async () => {
@@ -13,10 +14,14 @@ export default function LocationWidgetWrapper() {
           setLoading(true)
           const res = await fetch('api/metrics')
           const data = await res.json()
-          setLocations(data.locations)          
+          setLocations(data.locations)   
+          setError(data.error || null)     
         } catch (e) {
           console.log(e)
-          throw new Error('Error fetching location data')          
+          if (e instanceof Error) {
+            const errorMessage = e.message
+            setError(errorMessage)
+          }
         } finally {
           setLoading(false)
         }
@@ -29,7 +34,15 @@ export default function LocationWidgetWrapper() {
       { loading ? (
         <div className="p-4 rounded-lg bg-white border border-gray-300 shadow-md">Loading...</div>
       ) : (
-        <LocationWidget locations={locations} />
+        <>
+          {error ? (
+            <div className="p-4 rounded-lg bg-yellow-100 border border-yellow-300 text-yellow-700">
+              {error}
+            </div>
+          ) : (
+           <LocationWidget locations={locations} />
+          )}
+        </>
       )}    
     </>
   )

--- a/src/app/components/sensors/SensorGrid.tsx
+++ b/src/app/components/sensors/SensorGrid.tsx
@@ -31,10 +31,6 @@ export function SensorGrid() {
         fetchData()
     }, [])
 
-    if (!sensors || !Array.isArray(sensors)) {
-        return <div>Loading...</div>;
-      }
-
       const getCategoryColor = (status: string) => {
         switch (status) {
           case "water": return "bg-blue-100 text-blue-800";
@@ -44,38 +40,41 @@ export function SensorGrid() {
       };
       
     return (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">                   
-          {sensors.map((sensor) => {
-            // const Icon = sensor.icon;
-            
-            return (
-              <Card key={sensor.id} className="relative border-gray-300 shadow-md">
-                <CardHeader className="pb-3">
-                  <div className="flex items-center justify-between">
-                    <div className="justify-begin">
-                        <CardTitle className="text-base flex items-center gap-2">
-                        {sensor.name}
-                        </CardTitle>
-                        <div className="flex gap-2">
-                            <p className="font-bold">Type:</p>
-                            {sensor.typeName}
-                        </div>
-                    </div>
-                    <Badge className={getCategoryColor(sensor.category)}>
-                        {sensor.category}
-                    </Badge>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">      
 
+          {sensors && (
+            <>          
+              {sensors.map((sensor) => {                
+                return (
+                  <Card key={sensor.id} className="relative border-gray-300 shadow-md">
+                    <CardHeader className="pb-3">
+                      <div className="flex items-center justify-between">
+                        <div className="justify-begin">
+                            <CardTitle className="text-base flex items-center gap-2">
+                            {sensor.name}
+                            </CardTitle>
+                            <div className="flex gap-2">
+                                <p className="font-bold">Type:</p>
+                                {sensor.typeName}
+                            </div>
+                        </div>
+                        <Badge className={getCategoryColor(sensor.category)}>
+                            {sensor.category}
+                        </Badge>
+
+                        
+                      </div>
+                    </CardHeader>
+                    <CardContent className="flex gap-2">
+                        <p className="font-bold">Locations: </p>
+                        <p>{sensor.locations}</p>
+                    </CardContent>
                     
-                  </div>
-                </CardHeader>
-                <CardContent className="flex gap-2">
-                    <p className="font-bold">Locations: </p>
-                    <p>{sensor.locations}</p>
-                </CardContent>
-                
-              </Card>
-            );
-          })}
+                  </Card>
+                );
+              })}
+            </>
+          )}             
         </div>
       );
 }

--- a/src/app/components/sensors/latest.tsx
+++ b/src/app/components/sensors/latest.tsx
@@ -9,6 +9,7 @@ export default function LatestFetch() {
     const [sensorCount, setSensorCount] = useState(0);
     const [latestFetch, setLatestFetch] = useState<Date>();
     const [diff, setDiff] = useState(0);
+    const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
         const fetchData = async () => {
@@ -16,12 +17,16 @@ export default function LatestFetch() {
                 setLoading(true)
                 const response = await fetch('/api/sensors/latest');
                 const data = await response.json();
-                setSensorCount(data.sensorCount.count); 
-                setLatestFetch(new Date(data.latestFetch.timestamp))                
+                if (data.error) {
+                  setError(data.error || null);
+                } else {
+                  setSensorCount(data.sensorCount.count);
+                  setLatestFetch(new Date(data.latestFetch.timestamp));
 
-                const diffMS = new Date().getTime() - (new Date(data.latestFetch.timestamp).getTime() || 0);
-                setDiff(Math.floor(diffMS / (1000 * 60 * 60 * 24)));
-            } catch (error) {
+                  const diffMS = new Date().getTime() - (new Date(data.latestFetch.timestamp).getTime() || 0);
+                  setDiff(Math.floor(diffMS / (1000 * 60 * 60 * 24)));
+                }
+              } catch (error) {
                 console.error('Error fetching sensor data:', error);
             } finally {
               setLoading(false)
@@ -34,41 +39,44 @@ export default function LatestFetch() {
     return (
         <>
         {/* Current Status */}
-        <Card className="lg:col-span-2 bg-white border-gray-200 shadow-md p-4">
-          <CardHeader>
-            <div className="flex items-center justify-between">
-              <CardTitle className="flex items-center gap-2">
-                <CircleStackIcon className="h-5 w-5 text-blue-600" />
-                System Status
-              </CardTitle>
-              {/* <Button 
-                // onClick={handleRefresh}
-                className="flex items-center gap-2"
-              >
-                <ArrowPathIcon className="h-4 w-4" />
-                Refresh
-              </Button> */}
+        {error ? (
+          <>
+            <div className="p-4 rounded-lg bg-yellow-100 border border-yellow-300 text-yellow-700">
+              {error}
             </div>
-          </CardHeader>
-          <CardContent>
-            { loading ? (
-              <div>Loading...</div>
-            ) : (
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                <div className="text-center">
-                  <div className="text-2xl font-bold text-green-600">{sensorCount}</div>
-                  <div className="text-sm text-slate-600">Active Sensors</div>
-                  <Badge className="mt-1 bg-green-100 text-green-800">All Online</Badge>
-                </div>              
-                <div className="text-center">
-                  <div className="text-2xl font-bold text-slate-900">{latestFetch?.toLocaleDateString()}</div>
-                  <div className="text-sm text-slate-600">Last Upload</div>
-                  <Badge className="mt-1 bg-gray-100 text-gray-800">{diff} days ago</Badge>
-                </div>              
-              </div>
-            )}
-          </CardContent>
-        </Card>
+          </>
+        ) : (
+          <>
+            <Card className="lg:col-span-2 bg-white border-gray-200 shadow-md p-4">
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <CardTitle className="flex items-center gap-2">
+                    <CircleStackIcon className="h-5 w-5 text-blue-600" />
+                    System Status
+                  </CardTitle>            
+                </div>
+              </CardHeader>
+              <CardContent>
+                { loading ? (
+                  <div>Loading...</div>
+                ) : (
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                    <div className="text-center">
+                      <div className="text-2xl font-bold text-green-600">{sensorCount}</div>
+                      <div className="text-sm text-slate-600">Active Sensors</div>
+                      <Badge className="mt-1 bg-green-100 text-green-800">All Online</Badge>
+                    </div>              
+                    <div className="text-center">
+                      <div className="text-2xl font-bold text-slate-900">{latestFetch?.toLocaleDateString()}</div>
+                      <div className="text-sm text-slate-600">Last Upload</div>
+                      <Badge className="mt-1 bg-gray-100 text-gray-800">{diff} days ago</Badge>
+                    </div>              
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </>
+        )}
 
         {/* Recent Activity */}
         {/* <Card>

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -57,7 +57,7 @@ export default function Profile() {
 
     return (
         <>
-         <div className="max-w-7xl mx-auto space-y-6 p-4">
+         <div className="max-w-7xl mx-auto space-y-6 p-4 mb-96">
                 {/* Profile Header */}
                 <div className="bg-white rounded-lg border border-gray-200 p-6">
                     {loading ? (

--- a/src/app/lib/cache.ts
+++ b/src/app/lib/cache.ts
@@ -24,3 +24,6 @@ type CacheEntry<T> = {
     });
   }
   
+  export function clearCache(): void {
+    cache.clear();
+  }

--- a/src/app/register/components/RegistrationStep2.tsx
+++ b/src/app/register/components/RegistrationStep2.tsx
@@ -25,6 +25,7 @@ export default function RegistrationStep2({ ainaList }: RegistrationFormProps) {
 
     const handleSkip = (e: React.MouseEvent<HTMLButtonElement>) => {
       e.preventDefault();
+      console.log('Skipping registration step 2, navigating to dashboard...')
       router.push('/dashboard')
     }    
 


### PR DESCRIPTION
dealt with a couple of bugs in this PR

BUG: signing out (with data still in cache), then signing in on another account (that shouldn't have that data) will grab the data from the cache and not a fresh query
FIX: made a helper function to clear the cache and called it in the api to sign out

Skipping setting up a location
BUG: sensor readings and pages will render in ALL data (historical from all places) or not handle errors gracefully
FIX: made catchers and states to handle errors when they come back as a NextJS response from the api endpoint